### PR TITLE
Fixes: useEffect / useLayoutEffect + useReducer

### DIFF
--- a/lib/create-gstore-test/use-effect.test.tsx
+++ b/lib/create-gstore-test/use-effect.test.tsx
@@ -447,7 +447,7 @@ describe("useEffect in useGStore", () => {
         expect(effectCleanupHook).not.toHaveBeenCalled();
       });
 
-      describe.skip("Handling nullish state updates", () => {
+      describe("Handling nullish state updates", () => {
         test("should not trigger effect or cleanup when setting state to null if the effect's dependencies remain unchanged", async () => {
           const effectHook = vi.fn();
           const effectCleanupHook = vi.fn();
@@ -1052,7 +1052,7 @@ describe("useEffect in useGStore", () => {
       });
     });
 
-    describe.skip("State update behavior", () => {
+    describe("State update behavior", () => {
       test("should run effect and cleanup on every state update via component interaction", async () => {
         const effectHook = vi.fn();
         const effectCleanupHook = vi.fn();

--- a/lib/create-gstore-test/use-layout-effect.test.tsx
+++ b/lib/create-gstore-test/use-layout-effect.test.tsx
@@ -468,7 +468,7 @@ describe("useLayoutEffect in useGStore", () => {
         expect(effectCleanupHook).not.toHaveBeenCalled();
       });
 
-      describe.skip("Handling nullish state updates", () => {
+      describe("Handling nullish state updates", () => {
         test("should not trigger effect or cleanup when setting state to null if the effect's dependencies remain unchanged", async () => {
           const effectHook = vi.fn();
           const effectCleanupHook = vi.fn();
@@ -1107,7 +1107,7 @@ describe("useLayoutEffect in useGStore", () => {
       });
     });
 
-    describe.skip("State update behavior", () => {
+    describe("State update behavior", () => {
       test("should run effect and cleanup on every state update via component interaction", async () => {
         const effectHook = vi.fn();
         const effectCleanupHook = vi.fn();

--- a/lib/create-gstore-test/use-reducer.test.tsx
+++ b/lib/create-gstore-test/use-reducer.test.tsx
@@ -177,7 +177,7 @@ describe("useReducer in useGStore", () => {
     });
   });
 
-  describe.skip("Reducer initialization with initializer function", () => {
+  describe("Reducer initialization with initializer function", () => {
     const initialCounter = 0;
     const createInitialState = (counter: number) => ({ counter });
     const createTestComponents = ({
@@ -256,6 +256,18 @@ describe("useReducer in useGStore", () => {
         state: { counter: 0 },
         dispatch: expect.any(Function),
       });
+    });
+
+    test("should update state correctly", async () => {
+      const { Counter } = createTestComponents();
+
+      const { getByTestId } = render(<Counter />);
+
+      expect(getByTestId("counter-value")).toHaveTextContent("0");
+
+      await userEvent.click(getByTestId("increase-button"));
+
+      expect(getByTestId("counter-value")).toHaveTextContent("1");
     });
   });
 });

--- a/lib/hooks/react-hooks.ts
+++ b/lib/hooks/react-hooks.ts
@@ -14,8 +14,8 @@ export class ReactHooksMock {
 
   private useState: typeof React.useState = (initialState?: any): any => {
     const store = this.context.getTopState();
-    store.next();
-    return store.getCurrent(initialState);
+    store.nextState();
+    return store.getCurrentState(initialState);
   };
 
   private useReducer: typeof React.useReducer = (
@@ -53,14 +53,14 @@ export class ReactHooksMock {
 
   private useEffect: typeof React.useEffect = (fn: any, deps: any) => {
     const store = this.context.getTopState();
-    store.next();
-    store.scheduleEffect({ fn, deps, type: "effect" });
+    store.nextEffect();
+    store.scheduleEffect({ fn, deps }, "effect");
   };
 
   private useLayoutEffect: typeof React.useEffect = (fn: any, deps: any) => {
     const store = this.context.getTopState();
-    store.next();
-    store.scheduleEffect({ fn, deps, type: "layout-effect" });
+    store.nextEffect();
+    store.scheduleEffect({ fn, deps }, "layout-effect");
   };
 
   private useSyncExternalStore: typeof React.useSyncExternalStore = (

--- a/lib/hooks/react-hooks.ts
+++ b/lib/hooks/react-hooks.ts
@@ -20,9 +20,12 @@ export class ReactHooksMock {
 
   private useReducer: typeof React.useReducer = (
     reducer: any,
-    initialState: any,
+    initialArg: any,
+    init?: any,
   ): [any, (action: any) => void] => {
-    const [state, setState] = this.useState(initialState);
+    const [state, setState] = this.useState(
+      typeof init === "function" ? init(initialArg) : initialArg,
+    );
     const dispatch = this.useCallback((action: any) => {
       setState((s: any) => reducer(s, action));
     }, []);


### PR DESCRIPTION
- Fix setting nullish state along with useEffect / useLayoutEffect by splitting states and effects in HookStore

- Add support of absent dependencies array in useEffect / useLayoutEffect ( #5)

- Add support of state init function in useReducer