### PR TITLE
#18: Workflows optimizations

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,10 +1,10 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths:
+      - 'docs/**'
 
 jobs:
   build:
@@ -21,7 +21,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm run lint
-    - run: npm run build
     - name: Build documentation site
       run: npm run build:docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,8 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
+    paths:
+      - 'docs/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  ORIGINAL_REPOSITORY_OWNER: evo-community
+
 permissions:
   contents: read
   pages: write
@@ -17,6 +20,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository_owner == env.ORIGINAL_REPOSITORY_OWNER
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,6 +44,7 @@ jobs:
           path: ./docs/dist
 
   deploy:
+    if: github.repository_owner == env.ORIGINAL_REPOSITORY_OWNER
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
`deploy-docs.yml`:

- Added a push trigger path constraint: `docs/**`

- Enabled only for the original repository (not forks) by checking the `repository_owner`

Concurrency settings were already in place.

`build-and-test.yml`:

- Split into two separate jobs: `build` and `build-docs`

- Removed push trigger on the `main` branch; kept only the pull request trigger on `main`, since builds for `main` are already handled in the `deploy-docs.yml` and `npm-publish.yml` workflows.